### PR TITLE
Enable database-backed search

### DIFF
--- a/audio.php
+++ b/audio.php
@@ -575,10 +575,10 @@ footer strong {
                 🛒 Carrito <span class="cart-count" id="cart-count">0</span>
             </a>
         </div>
-        <div class="search-container">
-            <input type="text" id="search-bar" placeholder="Buscar productos...">
-            <button class="search-btn">🔍</button>
-        </div>
+        <form class="search-container" action="buscar.php" method="GET">
+            <input type="text" id="search-bar" name="q" placeholder="Buscar productos...">
+            <button class="search-btn" type="submit">🔍</button>
+        </form>
     </header>
 
     <?php include 'productos.php'; ?>

--- a/buscar.php
+++ b/buscar.php
@@ -1,0 +1,58 @@
+<?php
+require_once 'conexion.php';
+
+$q = isset($_GET['q']) ? trim($_GET['q']) : '';
+$results = [];
+if ($q !== '') {
+    $stmt = $conexion->prepare("SELECT id, nombre, descripcion, precio_venta, imagen_url FROM productos WHERE nombre LIKE ? OR descripcion LIKE ?");
+    $like = '%' . $q . '%';
+    $stmt->bind_param('ss', $like, $like);
+    $stmt->execute();
+    $res = $stmt->get_result();
+    while ($row = $res->fetch_assoc()) {
+        $results[] = $row;
+    }
+    $stmt->close();
+}
+?>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Resultados de búsqueda</title>
+    <link rel="icon" type="image/png" href="imagenes/logo.png">
+    <style>
+        body { font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif; background: #f5f5f5; margin: 0; padding: 2rem; }
+        h2 { text-align: center; margin-bottom: 2rem; }
+        .results { max-width: 900px; margin: 0 auto; }
+        .product { display: flex; gap: 1rem; background: #fff; padding: 1rem; border-radius: 8px; box-shadow: 0 2px 6px rgba(0,0,0,0.1); margin-bottom: 1rem; }
+        .product img { width: 100px; height: 100px; object-fit: contain; }
+        .product-info h3 { margin: 0 0 .5rem; }
+        .product-info p { margin: .3rem 0; }
+    </style>
+</head>
+<body>
+    <h2>Resultados de búsqueda para "<?php echo htmlspecialchars($q, ENT_QUOTES, 'UTF-8'); ?>"</h2>
+    <div class="results">
+        <?php if (!empty($results)): ?>
+            <?php foreach ($results as $prod): ?>
+                <div class="product">
+                    <?php if (!empty($prod['imagen_url'])): ?>
+                        <img src="<?php echo htmlspecialchars($prod['imagen_url'], ENT_QUOTES, 'UTF-8'); ?>" alt="<?php echo htmlspecialchars($prod['nombre'], ENT_QUOTES, 'UTF-8'); ?>">
+                    <?php endif; ?>
+                    <div class="product-info">
+                        <h3><?php echo htmlspecialchars($prod['nombre'], ENT_QUOTES, 'UTF-8'); ?></h3>
+                        <?php if (!empty($prod['descripcion'])): ?>
+                            <p><?php echo htmlspecialchars($prod['descripcion'], ENT_QUOTES, 'UTF-8'); ?></p>
+                        <?php endif; ?>
+                        <p>Precio: $<?php echo number_format($prod['precio_venta'], 2); ?></p>
+                    </div>
+                </div>
+            <?php endforeach; ?>
+        <?php else: ?>
+            <p>No se encontraron productos.</p>
+        <?php endif; ?>
+    </div>
+</body>
+</html>
+<?php $conexion->close(); ?>

--- a/cableado.php
+++ b/cableado.php
@@ -575,10 +575,10 @@ footer strong {
                 🛒 Carrito <span class="cart-count" id="cart-count">0</span>
             </a>
         </div>
-        <div class="search-container">
-            <input type="text" id="search-bar" placeholder="Buscar productos...">
-            <button class="search-btn">🔍</button>
-        </div>
+        <form class="search-container" action="buscar.php" method="GET">
+            <input type="text" id="search-bar" name="q" placeholder="Buscar productos...">
+            <button class="search-btn" type="submit">🔍</button>
+        </form>
     </header>
 
     <h2 class="section-title">Productos de Cableado</h2>

--- a/componentes.php
+++ b/componentes.php
@@ -575,10 +575,10 @@ footer strong {
                 🛒 Carrito <span class="cart-count" id="cart-count">0</span>
             </a>
         </div>
-        <div class="search-container">
-            <input type="text" id="search-bar" placeholder="Buscar productos...">
-            <button class="search-btn">🔍</button>
-        </div>
+        <form class="search-container" action="buscar.php" method="GET">
+            <input type="text" id="search-bar" name="q" placeholder="Buscar productos...">
+            <button class="search-btn" type="submit">🔍</button>
+        </form>
     </header>
 
     <h2 class="section-title">Productos de Componentes</h2>

--- a/electronica.php
+++ b/electronica.php
@@ -575,10 +575,10 @@ footer strong {
                 🛒 Carrito <span class="cart-count" id="cart-count">0</span>
             </a>
         </div>
-        <div class="search-container">
-            <input type="text" id="search-bar" placeholder="Buscar productos...">
-            <button class="search-btn">🔍</button>
-        </div>
+        <form class="search-container" action="buscar.php" method="GET">
+            <input type="text" id="search-bar" name="q" placeholder="Buscar productos...">
+            <button class="search-btn" type="submit">🔍</button>
+        </form>
     </header>
 
     <h2 class="section-title">PRODUCTOS DE ELECTRONICA</h2>

--- a/gaming.php
+++ b/gaming.php
@@ -168,25 +168,25 @@
   <header>
     <div class="header-content">
       <div class="logo">
-        <a href="index.html" style="text-decoration:none;color:inherit;"><h1>DIGITAL RP</h1></a>
+        <a href="index.php" style="text-decoration:none;color:inherit;"><h1>DIGITAL RP</h1></a>
       </div>
       <nav>
         <ul>
-          <li><a href="componentes.html">Componentes</a></li>
-          <li><a href="audio.html">Audio</a></li>
-          <li><a href="cableado.html">Cableado</a></li>
-          <li><a href="gaming.html" class="active">Gaming</a></li>
-          <li><a href="electronica.html">Electrónica</a></li>
-          <li><a href="varios.html">Varios</a></li>
+          <li><a href="componentes.php">Componentes</a></li>
+          <li><a href="audio.php">Audio</a></li>
+          <li><a href="cableado.php">Cableado</a></li>
+          <li><a href="gaming.php" class="active">Gaming</a></li>
+          <li><a href="electronica.php">Electrónica</a></li>
+          <li><a href="varios.php">Varios</a></li>
         </ul>
       </nav>
       <a href="#" class="cart-btn" onclick="toggleCart()">🛒 Carrito <span class="cart-count" id="cart-count">0</span></a>
     </div>
 
-    <div class="search-container" style="display:flex;justify-content:center;padding:1rem 2rem;background:rgba(255,255,255,.95);">
-      <input type="text" id="search-bar" placeholder="Buscar productos..." style="width:50%;padding:.8rem 1.5rem;border-radius:25px 0 0 25px;border:1px solid #ddd;border-right:none;font-size:1rem;">
-      <button class="search-btn" style="padding:.8rem 1.5rem;border-radius:0 25px 25px 0;border:1px solid #ddd;background:#f8f8f8;cursor:pointer;">🔍</button>
-    </div>
+    <form class="search-container" action="buscar.php" method="GET" style="display:flex;justify-content:center;padding:1rem 2rem;background:rgba(255,255,255,.95);">
+      <input type="text" id="search-bar" name="q" placeholder="Buscar productos..." style="width:50%;padding:.8rem 1.5rem;border-radius:25px 0 0 25px;border:1px solid #ddd;border-right:none;font-size:1rem;">
+      <button class="search-btn" type="submit" style="padding:.8rem 1.5rem;border-radius:0 25px 25px 0;border:1px solid #ddd;background:#f8f8f8;cursor:pointer;">🔍</button>
+    </form>
   </header>
 
   <section class="hero">

--- a/index.php
+++ b/index.php
@@ -742,28 +742,28 @@
     <header>
         <div class="header-content">
             <div class="logo">
-                <a href="index.html" style="text-decoration: none; color: inherit;">
+                <a href="index.php" style="text-decoration: none; color: inherit;">
                     <h1>DIGITAL RP</h1>
                 </a>
             </div>
             <nav>
                 <ul>
-                    <li><a href="componentes.html">Componentes</a></li>
-                    <li><a href="audio.html">Audio</a></li>
-                    <li><a href="cableado.html">Cableado</a></li>
-                    <li><a href="gaming.html">Gaming</a></li>
-                    <li><a href="electronica.html">Electrónica</a></li>
-                    <li><a href="varios.html">Varios</a></li>
+                    <li><a href="componentes.php">Componentes</a></li>
+                    <li><a href="audio.php">Audio</a></li>
+                    <li><a href="cableado.php">Cableado</a></li>
+                    <li><a href="gaming.php">Gaming</a></li>
+                    <li><a href="electronica.php">Electrónica</a></li>
+                    <li><a href="varios.php">Varios</a></li>
                 </ul>
             </nav>
             <a href="#" class="cart-btn" onclick="toggleCart()">
                 🛒 Carrito <span class="cart-count" id="cart-count">0</span>
             </a>
         </div>
-        <div class="search-container">
-            <input type="text" id="search-bar" placeholder="Buscar productos...">
-            <button class="search-btn">🔍</button>
-        </div>
+        <form class="search-container" action="buscar.php" method="GET">
+            <input type="text" id="search-bar" name="q" placeholder="Buscar productos...">
+            <button class="search-btn" type="submit">🔍</button>
+        </form>
     </header>
 
     <section class="hero">
@@ -778,41 +778,41 @@
         <div class="categories-container">
             <h2 class="section-title">Nuestras Categorías</h2>
             <div class="categories-grid">
-                <div class="category-card" onclick="window.location.href='componentes.html'">
+                <div class="category-card" onclick="window.location.href='componentes.php'">
                     <div class="category-icon">🖥️</div>
                     <h3>Componentes y Periféricos</h3>
                     <p>Mouses, teclados, monitores y más componentes esenciales</p>
-                    <a href="componentes.html" class="category-btn">Ver Productos</a>
+                    <a href="componentes.php" class="category-btn">Ver Productos</a>
                 </div>
-                <div class="category-card" onclick="window.location.href='audio.html'">
+                <div class="category-card" onclick="window.location.href='audio.php'">
                     <div class="category-icon">🎵</div>
                     <h3>Audio</h3>
                     <p>Audífonos, bocinas y equipos de sonido profesional</p>
-                    <a href="audio.html" class="category-btn">Ver Productos</a>
+                    <a href="audio.php" class="category-btn">Ver Productos</a>
                 </div>
-                <div class="category-card" onclick="window.location.href='cableado.html'">
+                <div class="category-card" onclick="window.location.href='cableado.php'">
                     <div class="category-icon">🔌</div>
                     <h3>Cableado</h3>
                     <p>Cables, adaptadores y accesorios de conectividad</p>
-                    <a href="cableado.html" class="category-btn">Ver Productos</a>
+                    <a href="cableado.php" class="category-btn">Ver Productos</a>
                 </div>
-                <div class="category-card" onclick="window.location.href='gaming.html'">
+                <div class="category-card" onclick="window.location.href='gaming.php'">
                     <div class="category-icon">🎮</div>
                     <h3>Gaming</h3>
                     <p>Sillas gamer, pantallas y accesorios para gamers</p>
-                    <a href="gaming.html" class="category-btn">Ver Productos</a>
+                    <a href="gaming.php" class="category-btn">Ver Productos</a>
                 </div>
-                <div class="category-card" onclick="window.location.href='electronica.html'">
+                <div class="category-card" onclick="window.location.href='electronica.php'">
                     <div class="category-icon">💡</div>
                     <h3>Electrónica</h3>
                     <p>Componentes y dispositivos electrónicos</p>
-                    <a href="electronica.html" class="category-btn">Ver Productos</a>
+                    <a href="electronica.php" class="category-btn">Ver Productos</a>
                 </div>
-                <div class="category-card" onclick="window.location.href='varios.html'">
+                <div class="category-card" onclick="window.location.href='varios.php'">
                     <div class="category-icon">📦</div>
                     <h3>Varios</h3>
                     <p>Productos y accesorios diversos</p>
-                    <a href="varios.html" class="category-btn">Ver Productos</a>
+                    <a href="varios.php" class="category-btn">Ver Productos</a>
                 </div>
             </div>
         </div>

--- a/varios.php
+++ b/varios.php
@@ -575,10 +575,10 @@ footer strong {
                 🛒 Carrito <span class="cart-count" id="cart-count">0</span>
             </a>
         </div>
-        <div class="search-container">
-            <input type="text" id="search-bar" placeholder="Buscar productos...">
-            <button class="search-btn">🔍</button>
-        </div>
+        <form class="search-container" action="buscar.php" method="GET">
+            <input type="text" id="search-bar" name="q" placeholder="Buscar productos...">
+            <button class="search-btn" type="submit">🔍</button>
+        </form>
     </header>
 
     <h2 class="section-title">Productos Varios</h2>


### PR DESCRIPTION
## Summary
- Convert header search bars into forms that submit queries
- Add `buscar.php` to fetch products from the database and show matches
- Link navigation and category cards to `.php` pages to avoid `.html` connection errors

## Testing
- `php -l index.php audio.php componentes.php electronica.php gaming.php cableado.php varios.php buscar.php`


------
https://chatgpt.com/codex/tasks/task_b_6897f86de3b48321a722bfbb25d42b8d