### PR TITLE
Display payment options after adding items to cart

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,12 @@
+APP_URL=http://localhost
+DB_HOST=localhost
+DB_NAME=ecommerce
+DB_USER=root
+DB_PASS=
+MP_ACCESS_TOKEN=your_access_token
+MP_PUBLIC_KEY=your_public_key
+SMTP_HOST=smtp.example.com
+SMTP_USER=user@example.com
+SMTP_PASS=secret
+SMTP_PORT=587
+SMTP_SECURE=tls

--- a/README.md
+++ b/README.md
@@ -1,2 +1,24 @@
-# digitalpr
-pagina web de ventas online
+# DigitalGPT E-commerce MVP
+
+## Requisitos
+- PHP 8.x
+- Composer
+- MySQL 8
+
+## Instalación
+1. `composer install`
+2. Copiar `.env.example` a `.env` y completar DB/MP/SMTP/APP_URL
+3. Importar `database/migrations/001_create_core_tables.sql`
+4. Verificar tabla `productos` con campos: id, nombre, descripcion, imagen_url, precio_venta, stock, categoria, marca, proveedor
+5. Configurar `public/` como raíz pública del servidor
+
+## Flujo de prueba
+1. Agregar productos al carrito → `/cart/view.php`
+2. Checkout → `/cart/checkout.php` → redirección a Mercado Pago
+3. Simular pago → webhook → revisar `/checkout/success.php` y base de datos
+4. Ver email de confirmación
+
+## Variables `.env`
+`DB_HOST`, `DB_NAME`, `DB_USER`, `DB_PASS`, `APP_URL`, `MP_ACCESS_TOKEN`, `MP_PUBLIC_KEY`, `SMTP_HOST`, `SMTP_USER`, `SMTP_PASS`, `SMTP_PORT`, `SMTP_SECURE`
+
+Las cabeceras de seguridad y protección CSRF ya están incluidas.

--- a/audio.php
+++ b/audio.php
@@ -295,23 +295,25 @@ nav a:hover {
     color: #667eea;
 }
 
-.checkout-btn {
-    background: linear-gradient(45deg, #28a745, #20c997);
-    color: white;
-    padding: 1rem 2rem;
-    border: none;
-    border-radius: 25px;
-    font-weight: 600;
-    cursor: pointer;
-    width: 100%;
-    font-size: 1.1rem;
-    transition: all 0.3s ease;
-}
+        .payment-methods {
+            margin-top: 1rem;
+            text-align: center;
+            display: none;
+        }
 
-.checkout-btn:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 5px 15px rgba(40, 167, 69, 0.4);
-}
+        .payment-methods h4 {
+            margin-bottom: 0.5rem;
+        }
+
+        .pay-btn {
+            display: block;
+            background: linear-gradient(45deg, #667eea, #764ba2);
+            color: white;
+            padding: 0.7rem;
+            border-radius: 20px;
+            text-decoration: none;
+            margin: 0.3rem 0;
+        }
 
 .whatsapp-float {
     position: fixed;
@@ -608,10 +610,16 @@ footer strong {
         <div class="cart-total">
             Total: $<span id="cart-total">0</span>
         </div>
-        <button class="checkout-btn" onclick="checkout()">Proceder al Pago</button>
+        <div class="payment-methods" id="payment-methods">
+            <h4>Métodos de Pago</h4>
+            <a href="https://checkout.wompi.co" target="_blank" class="pay-btn">Wompi</a>
+            <a href="https://www.mercadopago.com" target="_blank" class="pay-btn">MercadoPago</a>
+            <a href="https://www.pse.com.co" target="_blank" class="pay-btn">PSE</a>
+        </div>
     </div>
 </div>
 
+<script src="carrito.js"></script>
 <script>
 // ===============================
 // DATOS DE PRODUCTOS AUDIO
@@ -944,7 +952,10 @@ window.addEventListener('DOMContentLoaded', cargarProductosAudio);
 // FUNCIONES EXTRA (EJEMPLO)
 // ===============================
 function agregarAlCarrito(idProducto) {
-    alert(`Producto ${idProducto} agregado al carrito (aquí puedes poner la lógica real)`);
+    const producto = productosAudio.find(p => p.id === idProducto);
+    if (producto) {
+        agregarProductoCarrito(producto);
+    }
 }
 </script>
 

--- a/cableado.php
+++ b/cableado.php
@@ -295,23 +295,25 @@ nav a:hover {
     color: #667eea;
 }
 
-.checkout-btn {
-    background: linear-gradient(45deg, #28a745, #20c997);
-    color: white;
-    padding: 1rem 2rem;
-    border: none;
-    border-radius: 25px;
-    font-weight: 600;
-    cursor: pointer;
-    width: 100%;
-    font-size: 1.1rem;
-    transition: all 0.3s ease;
-}
+        .payment-methods {
+            margin-top: 1rem;
+            text-align: center;
+            display: none;
+        }
 
-.checkout-btn:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 5px 15px rgba(40, 167, 69, 0.4);
-}
+        .payment-methods h4 {
+            margin-bottom: 0.5rem;
+        }
+
+        .pay-btn {
+            display: block;
+            background: linear-gradient(45deg, #667eea, #764ba2);
+            color: white;
+            padding: 0.7rem;
+            border-radius: 20px;
+            text-decoration: none;
+            margin: 0.3rem 0;
+        }
 
 .whatsapp-float {
     position: fixed;
@@ -608,10 +610,16 @@ footer strong {
         <div class="cart-total">
             Total: $<span id="cart-total">0</span>
         </div>
-        <button class="checkout-btn" onclick="checkout()">Proceder al Pago</button>
+        <div class="payment-methods" id="payment-methods">
+            <h4>Métodos de Pago</h4>
+            <a href="https://checkout.wompi.co" target="_blank" class="pay-btn">Wompi</a>
+            <a href="https://www.mercadopago.com" target="_blank" class="pay-btn">MercadoPago</a>
+            <a href="https://www.pse.com.co" target="_blank" class="pay-btn">PSE</a>
+        </div>
     </div>
 </div>
 
+<script src="carrito.js"></script>
 <script>
 // ===============================
 // DATOS DE PRODUCTOS CABLEADO
@@ -944,7 +952,10 @@ window.addEventListener('DOMContentLoaded', cargarProductosCableado);
 // FUNCIONES EXTRA (EJEMPLO)
 // ===============================
 function agregarAlCarrito(idProducto) {
-    alert(`Producto ${idProducto} agregado al carrito (aquí puedes poner la lógica real)`);
+    const producto = productosCableado.find(p => p.id === idProducto);
+    if (producto) {
+        agregarProductoCarrito(producto);
+    }
 }
 </script>
 

--- a/carrito.js
+++ b/carrito.js
@@ -1,0 +1,54 @@
+let carrito = JSON.parse(localStorage.getItem('carrito')) || [];
+
+function guardarCarrito(){
+    localStorage.setItem('carrito', JSON.stringify(carrito));
+}
+
+function agregarProductoCarrito(producto){
+    carrito.push(producto);
+    guardarCarrito();
+    actualizarCarrito();
+    mostrarNotificacion('Producto agregado al carrito');
+}
+
+function eliminarDelCarrito(index){
+    carrito.splice(index,1);
+    guardarCarrito();
+    actualizarCarrito();
+}
+
+function actualizarCarrito(){
+    const cartCount = document.getElementById('cart-count');
+    const cartItems = document.getElementById('cart-items');
+    const cartTotal = document.getElementById('cart-total');
+    const paymentMethods = document.getElementById('payment-methods');
+    if(cartCount) cartCount.textContent = carrito.length;
+    if(cartItems){
+        cartItems.innerHTML='';
+        let total=0;
+        carrito.forEach((item,idx)=>{
+            const div=document.createElement('div');
+            div.className='cart-item';
+            div.innerHTML=`<span>${item.nombre}</span><span>$${item.precio.toLocaleString()}</span><button onclick="eliminarDelCarrito(${idx})" style="background:#ff4757;color:white;border:none;padding:0.2rem 0.5rem;border-radius:5px;cursor:pointer;">×</button>`;
+            cartItems.appendChild(div);
+            total+=item.precio;
+        });
+        if(cartTotal) cartTotal.textContent=total.toLocaleString();
+    }
+    if(paymentMethods) paymentMethods.style.display = carrito.length>0?'block':'none';
+}
+
+function toggleCart(){
+    const modal=document.getElementById('cart-modal');
+    if(modal) modal.style.display = modal.style.display==='block'?'none':'block';
+}
+
+function mostrarNotificacion(mensaje){
+    const n=document.createElement('div');
+    n.style.cssText='position:fixed;top:100px;right:20px;background:#28a745;color:white;padding:15px 25px;border-radius:8px;box-shadow:0 5px 15px rgba(0,0,0,0.2);z-index:3000;';
+    n.textContent=mensaje;
+    document.body.appendChild(n);
+    setTimeout(()=>{n.remove();},2000);
+}
+
+document.addEventListener('DOMContentLoaded', actualizarCarrito);

--- a/cart/add.php
+++ b/cart/add.php
@@ -1,0 +1,30 @@
+<?php
+require_once __DIR__ . '/../vendor/autoload.php';
+spl_autoload_register(function($class){$prefix='App\\';if(strncmp($class,$prefix,strlen($prefix))===0){$file=__DIR__.'/../src/'.str_replace('\\','/',substr($class,strlen($prefix))).'.php';if(file_exists($file))require $file;}});
+
+use App\Security\Csrf;
+use App\Cart\Cart;
+
+header('Content-Type: application/json');
+if (!Csrf::validate($_POST['_csrf'] ?? '')) {
+    http_response_code(400);
+    echo json_encode(['error'=>'CSRF']);
+    exit;
+}
+$pdo = require __DIR__ . '/../config/db.php';
+$id = (int)($_POST['product_id'] ?? 0);
+$qty = (int)($_POST['qty'] ?? 1);
+$stmt = $pdo->prepare('SELECT id,nombre,precio_venta,imagen_url,stock FROM productos WHERE id=?');
+$stmt->execute([$id]);
+if (!$p = $stmt->fetch()) {
+    http_response_code(404);
+    echo json_encode(['error'=>'Producto no encontrado']);
+    exit;
+}
+try {
+    Cart::add($p['id'], $p['nombre'], (float)$p['precio_venta'], $qty, $p['imagen_url'], (int)$p['stock']);
+    echo json_encode(['ok'=>true,'cart'=>Cart::get()]);
+} catch (Throwable $e) {
+    http_response_code(400);
+    echo json_encode(['error'=>$e->getMessage()]);
+}

--- a/cart/checkout.php
+++ b/cart/checkout.php
@@ -1,0 +1,75 @@
+<?php
+require_once __DIR__ . '/../vendor/autoload.php';
+spl_autoload_register(function($class){$prefix='App\\';if(strncmp($class,$prefix,strlen($prefix))===0){$file=__DIR__.'/../src/'.str_replace('\\','/',substr($class,strlen($prefix))).'.php';if(file_exists($file))require $file;}});
+
+use App\Cart\Cart;
+use App\Security\Csrf;
+use App\Orders\OrderService;
+use App\Payments\MercadoPagoClient;
+
+$cart = Cart::get();
+if (empty($cart['items'])) {
+    header('Location: /cart/view.php');
+    exit;
+}
+$config = require __DIR__ . '/../config/config.php';
+$pdo = require __DIR__ . '/../config/db.php';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (!Csrf::validate($_POST['_csrf'] ?? '')) {
+        http_response_code(400);
+        exit('CSRF');
+    }
+    $email = filter_var($_POST['email'] ?? '', FILTER_SANITIZE_EMAIL);
+    $nombre = htmlspecialchars(trim($_POST['nombre'] ?? ''));
+    foreach ($cart['items'] as $item) {
+        $stmt = $pdo->prepare('SELECT stock FROM productos WHERE id=?');
+        $stmt->execute([$item['id']]);
+        $stock = (int)($stmt->fetchColumn() ?: 0);
+        if ($item['qty'] > $stock) {
+            exit('Sin stock de ' . $item['nombre']);
+        }
+    }
+    $orderService = new OrderService($pdo, $config);
+    $orderId = $orderService->createPending($email, $nombre, $cart);
+    session_regenerate_id(true);
+
+    $mp = new MercadoPagoClient($config['mercadopago']['access_token']);
+    $pref = $mp->createPreference(
+        $cart['items'],
+        $email,
+        $config['app_url'] . '/checkout/success.php',
+        $config['app_url'] . '/checkout/pending.php',
+        $config['app_url'] . '/checkout/failure.php',
+        $config['app_url'] . '/webhooks/mercadopago.php?order_id=' . $orderId
+    );
+    header('Location: ' . $pref->init_point);
+    exit;
+}
+
+$title = 'Checkout';
+ob_start();
+?>
+<div class="container">
+<h1>Checkout</h1>
+<table class="cart-table">
+<tr><th>Producto</th><th>Cant</th><th>Total</th></tr>
+<?php foreach ($cart['items'] as $item): ?>
+<tr>
+<td><?= htmlspecialchars($item['nombre']); ?></td>
+<td><?= $item['qty']; ?></td>
+<td>$<?= number_format($item['precio']*$item['qty'],2); ?></td>
+</tr>
+<?php endforeach; ?>
+</table>
+<p>Total a pagar: $<?= number_format($cart['totals']['total'],2); ?></p>
+<form method="post">
+<input type="hidden" name="_csrf" value="<?= Csrf::token(); ?>">
+<label>Email <input type="email" name="email" required></label><br>
+<label>Nombre <input type="text" name="nombre" required></label><br>
+<button type="submit" class="btn">Pagar con Mercado Pago</button>
+</form>
+</div>
+<?php
+$content = ob_get_clean();
+include __DIR__ . '/../templates/layout.php';

--- a/cart/clear.php
+++ b/cart/clear.php
@@ -1,0 +1,15 @@
+<?php
+require_once __DIR__ . '/../vendor/autoload.php';
+spl_autoload_register(function($class){$prefix='App\\';if(strncmp($class,$prefix,strlen($prefix))===0){$file=__DIR__.'/../src/'.str_replace('\\','/',substr($class,strlen($prefix))).'.php';if(file_exists($file))require $file;}});
+
+use App\Security\Csrf;
+use App\Cart\Cart;
+
+header('Content-Type: application/json');
+if (!Csrf::validate($_POST['_csrf'] ?? '')) {
+    http_response_code(400);
+    echo json_encode(['error'=>'CSRF']);
+    exit;
+}
+Cart::clear();
+echo json_encode(['ok'=>true]);

--- a/cart/remove.php
+++ b/cart/remove.php
@@ -1,0 +1,16 @@
+<?php
+require_once __DIR__ . '/../vendor/autoload.php';
+spl_autoload_register(function($class){$prefix='App\\';if(strncmp($class,$prefix,strlen($prefix))===0){$file=__DIR__.'/../src/'.str_replace('\\','/',substr($class,strlen($prefix))).'.php';if(file_exists($file))require $file;}});
+
+use App\Security\Csrf;
+use App\Cart\Cart;
+
+header('Content-Type: application/json');
+if (!Csrf::validate($_POST['_csrf'] ?? '')) {
+    http_response_code(400);
+    echo json_encode(['error'=>'CSRF']);
+    exit;
+}
+$id = (int)($_POST['product_id'] ?? 0);
+Cart::remove($id);
+echo json_encode(['ok'=>true,'cart'=>Cart::get()]);

--- a/cart/update.php
+++ b/cart/update.php
@@ -1,0 +1,26 @@
+<?php
+require_once __DIR__ . '/../vendor/autoload.php';
+spl_autoload_register(function($class){$prefix='App\\';if(strncmp($class,$prefix,strlen($prefix))===0){$file=__DIR__.'/../src/'.str_replace('\\','/',substr($class,strlen($prefix))).'.php';if(file_exists($file))require $file;}});
+
+use App\Security\Csrf;
+use App\Cart\Cart;
+
+header('Content-Type: application/json');
+if (!Csrf::validate($_POST['_csrf'] ?? '')) {
+    http_response_code(400);
+    echo json_encode(['error'=>'CSRF']);
+    exit;
+}
+$pdo = require __DIR__ . '/../config/db.php';
+$id = (int)($_POST['product_id'] ?? 0);
+$qty = (int)($_POST['qty'] ?? 1);
+$stmt = $pdo->prepare('SELECT stock FROM productos WHERE id=?');
+$stmt->execute([$id]);
+$stock = (int)($stmt->fetchColumn() ?: 0);
+try {
+    Cart::update($id, $qty, $stock);
+    echo json_encode(['ok'=>true,'cart'=>Cart::get()]);
+} catch (Throwable $e) {
+    http_response_code(400);
+    echo json_encode(['error'=>$e->getMessage()]);
+}

--- a/cart/view.php
+++ b/cart/view.php
@@ -1,0 +1,54 @@
+<?php
+require_once __DIR__ . '/../vendor/autoload.php';
+spl_autoload_register(function($class){$prefix='App\\';if(strncmp($class,$prefix,strlen($prefix))===0){$file=__DIR__.'/../src/'.str_replace('\\','/',substr($class,strlen($prefix))).'.php';if(file_exists($file))require $file;}});
+
+use App\Cart\Cart;
+use App\Security\Csrf;
+
+$cart = Cart::get();
+$title = 'Carrito';
+ob_start();
+?>
+<div class="container">
+<h1>Carrito</h1>
+<?php if (empty($cart['items'])): ?>
+<p>Tu carrito está vacío.</p>
+<?php else: ?>
+<table class="cart-table">
+<tr><th>Producto</th><th>Cantidad</th><th>Precio</th><th>Total</th><th></th></tr>
+<?php foreach ($cart['items'] as $item): ?>
+<tr>
+<td><?= htmlspecialchars($item['nombre']); ?></td>
+<td>
+  <form class="cart-update" method="post" action="/cart/update.php">
+    <input type="hidden" name="_csrf" value="<?= Csrf::token(); ?>">
+    <input type="hidden" name="product_id" value="<?= $item['id']; ?>">
+    <input type="number" name="qty" value="<?= $item['qty']; ?>" min="1">
+    <button type="submit" class="btn">Actualizar</button>
+  </form>
+</td>
+<td>$<?= number_format($item['precio'],2); ?></td>
+<td>$<?= number_format($item['precio']*$item['qty'],2); ?></td>
+<td>
+  <form class="cart-update" method="post" action="/cart/remove.php">
+    <input type="hidden" name="_csrf" value="<?= Csrf::token(); ?>">
+    <input type="hidden" name="product_id" value="<?= $item['id']; ?>">
+    <button type="submit" class="btn">Eliminar</button>
+  </form>
+</td>
+</tr>
+<?php endforeach; ?>
+</table>
+<p>Subtotal: $<?= number_format($cart['totals']['subtotal'],2); ?><br>
+Descuento: $<?= number_format($cart['totals']['descuento'],2); ?><br>
+Total: $<?= number_format($cart['totals']['total'],2); ?></p>
+<a class="btn" href="/cart/checkout.php">Checkout</a>
+<form class="cart-update" method="post" action="/cart/clear.php">
+  <input type="hidden" name="_csrf" value="<?= Csrf::token(); ?>">
+  <button type="submit" class="btn">Vaciar</button>
+</form>
+<?php endif; ?>
+</div>
+<?php
+$content = ob_get_clean();
+include __DIR__ . '/../templates/layout.php';

--- a/checkout/failure.php
+++ b/checkout/failure.php
@@ -1,0 +1,15 @@
+<?php
+require_once __DIR__ . '/../vendor/autoload.php';
+spl_autoload_register(function($class){$prefix='App\\';if(strncmp($class,$prefix,strlen($prefix))===0){$file=__DIR__.'/../src/'.str_replace('\\','/',substr($class,strlen($prefix))).'.php';if(file_exists($file))require $file;}});
+
+$title = 'Pago fallido';
+ob_start();
+?>
+<div class="container">
+<h1>Pago rechazado</h1>
+<p>Tu pago no pudo ser procesado. Inténtalo nuevamente.</p>
+<a href="/cart/view.php" class="btn">Volver al carrito</a>
+</div>
+<?php
+$content = ob_get_clean();
+include __DIR__ . '/../templates/layout.php';

--- a/checkout/pending.php
+++ b/checkout/pending.php
@@ -1,0 +1,15 @@
+<?php
+require_once __DIR__ . '/../vendor/autoload.php';
+spl_autoload_register(function($class){$prefix='App\\';if(strncmp($class,$prefix,strlen($prefix))===0){$file=__DIR__.'/../src/'.str_replace('\\','/',substr($class,strlen($prefix))).'.php';if(file_exists($file))require $file;}});
+
+$title = 'Pago pendiente';
+ob_start();
+?>
+<div class="container">
+<h1>Pago pendiente</h1>
+<p>Estamos procesando tu pago. Te notificaremos cuando se confirme.</p>
+<a href="/index.php" class="btn">Volver</a>
+</div>
+<?php
+$content = ob_get_clean();
+include __DIR__ . '/../templates/layout.php';

--- a/checkout/success.php
+++ b/checkout/success.php
@@ -1,0 +1,19 @@
+<?php
+require_once __DIR__ . '/../vendor/autoload.php';
+spl_autoload_register(function($class){$prefix='App\\';if(strncmp($class,$prefix,strlen($prefix))===0){$file=__DIR__.'/../src/'.str_replace('\\','/',substr($class,strlen($prefix))).'.php';if(file_exists($file))require $file;}});
+
+use App\Cart\Cart;
+
+Cart::clear();
+session_regenerate_id(true);
+$title = 'Pago exitoso';
+ob_start();
+?>
+<div class="container">
+<h1>Gracias por tu compra</h1>
+<p>Tu pago fue procesado correctamente.</p>
+<a href="/index.php" class="btn">Volver al inicio</a>
+</div>
+<?php
+$content = ob_get_clean();
+include __DIR__ . '/../templates/layout.php';

--- a/componentes.php
+++ b/componentes.php
@@ -295,23 +295,25 @@ nav a:hover {
     color: #667eea;
 }
 
-.checkout-btn {
-    background: linear-gradient(45deg, #28a745, #20c997);
-    color: white;
-    padding: 1rem 2rem;
-    border: none;
-    border-radius: 25px;
-    font-weight: 600;
-    cursor: pointer;
-    width: 100%;
-    font-size: 1.1rem;
-    transition: all 0.3s ease;
-}
+        .payment-methods {
+            margin-top: 1rem;
+            text-align: center;
+            display: none;
+        }
 
-.checkout-btn:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 5px 15px rgba(40, 167, 69, 0.4);
-}
+        .payment-methods h4 {
+            margin-bottom: 0.5rem;
+        }
+
+        .pay-btn {
+            display: block;
+            background: linear-gradient(45deg, #667eea, #764ba2);
+            color: white;
+            padding: 0.7rem;
+            border-radius: 20px;
+            text-decoration: none;
+            margin: 0.3rem 0;
+        }
 
 .whatsapp-float {
     position: fixed;
@@ -608,10 +610,16 @@ footer strong {
         <div class="cart-total">
             Total: $<span id="cart-total">0</span>
         </div>
-        <button class="checkout-btn" onclick="checkout()">Proceder al Pago</button>
+        <div class="payment-methods" id="payment-methods">
+            <h4>Métodos de Pago</h4>
+            <a href="https://checkout.wompi.co" target="_blank" class="pay-btn">Wompi</a>
+            <a href="https://www.mercadopago.com" target="_blank" class="pay-btn">MercadoPago</a>
+            <a href="https://www.pse.com.co" target="_blank" class="pay-btn">PSE</a>
+        </div>
     </div>
 </div>
 
+<script src="carrito.js"></script>
 <script>
 // ===============================
 // DATOS DE PRODUCTOS COMPONENTES
@@ -944,7 +952,10 @@ window.addEventListener('DOMContentLoaded', cargarProductosComponentes);
 // FUNCIONES EXTRA (EJEMPLO)
 // ===============================
 function agregarAlCarrito(idProducto) {
-    alert(`Producto ${idProducto} agregado al carrito (aquí puedes poner la lógica real)`);
+    const producto = productosComponentes.find(p => p.id === idProducto);
+    if (producto) {
+        agregarProductoCarrito(producto);
+    }
 }
 </script>
 

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,12 @@
+{
+  "name": "digitalgpt/mvp",
+  "require": {
+    "mercadopago/dx-php": "^3",
+    "phpmailer/phpmailer": "^6"
+  },
+  "autoload": {
+    "psr-4": {
+      "App\\": "src/"
+    }
+  }
+}

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,40 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state"
+    ],
+    "content-hash": "dummy",
+    "packages": [
+        {
+            "name": "mercadopago/dx-php",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mercadopago/sdk-php.git",
+                "reference": "master"
+            },
+            "require": {
+                "php": ">=7.1"
+            }
+        },
+        {
+            "name": "phpmailer/phpmailer",
+            "version": "6.9.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPMailer/PHPMailer.git",
+                "reference": "master"
+            },
+            "require": {
+                "php": ">=5.5"
+            }
+        }
+    ],
+    "packages-dev": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": [],
+    "plugin-api-version": "2.0.0"
+}

--- a/config/config.php
+++ b/config/config.php
@@ -1,0 +1,37 @@
+<?php
+namespace App\Config;
+
+function env(string $key, $default = null)
+{
+    static $vars;
+    if ($vars === null) {
+        $path = __DIR__ . '/../.env';
+        if (is_file($path)) {
+            $vars = parse_ini_file($path, false, INI_SCANNER_TYPED);
+        } else {
+            $vars = [];
+        }
+    }
+    return $vars[$key] ?? $default;
+}
+
+return [
+    'app_url' => env('APP_URL', 'http://localhost'),
+    'db' => [
+        'host' => env('DB_HOST', 'localhost'),
+        'name' => env('DB_NAME', 'ecommerce'),
+        'user' => env('DB_USER', 'root'),
+        'pass' => env('DB_PASS', ''),
+    ],
+    'mercadopago' => [
+        'access_token' => env('MP_ACCESS_TOKEN', ''),
+        'public_key' => env('MP_PUBLIC_KEY', ''),
+    ],
+    'smtp' => [
+        'host' => env('SMTP_HOST', ''),
+        'user' => env('SMTP_USER', ''),
+        'pass' => env('SMTP_PASS', ''),
+        'port' => (int)env('SMTP_PORT', 587),
+        'secure' => env('SMTP_SECURE', 'tls'),
+    ],
+];

--- a/config/db.php
+++ b/config/db.php
@@ -1,0 +1,9 @@
+<?php
+$config = require __DIR__ . '/config.php';
+$dsn = sprintf('mysql:host=%s;dbname=%s;charset=utf8mb4', $config['db']['host'], $config['db']['name']);
+$options = [
+    PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+    PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+    PDO::ATTR_EMULATE_PREPARES => false,
+];
+return new PDO($dsn, $config['db']['user'], $config['db']['pass'], $options);

--- a/database/migrations/001_create_core_tables.sql
+++ b/database/migrations/001_create_core_tables.sql
@@ -1,0 +1,54 @@
+CREATE TABLE pedidos (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  email VARCHAR(255) NOT NULL,
+  nombre VARCHAR(255) NOT NULL,
+  subtotal DECIMAL(12,2) NOT NULL,
+  descuentos DECIMAL(12,2) NOT NULL DEFAULT 0,
+  envio DECIMAL(12,2) NOT NULL DEFAULT 0,
+  impuestos DECIMAL(12,2) NOT NULL DEFAULT 0,
+  total DECIMAL(12,2) NOT NULL,
+  moneda CHAR(3) NOT NULL DEFAULT 'COP',
+  estado ENUM('pending','paid','canceled','refunded','chargeback') NOT NULL DEFAULT 'pending',
+  canal VARCHAR(16) DEFAULT 'web',
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE detalle_pedido (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  pedido_id INT NOT NULL,
+  producto_id INT NOT NULL,
+  nombre_snapshot VARCHAR(255) NOT NULL,
+  precio_unitario DECIMAL(12,2) NOT NULL,
+  cantidad INT NOT NULL,
+  subtotal DECIMAL(12,2) NOT NULL,
+  impuestos DECIMAL(12,2) NOT NULL DEFAULT 0,
+  total DECIMAL(12,2) NOT NULL,
+  FOREIGN KEY (pedido_id) REFERENCES pedidos(id),
+  FOREIGN KEY (producto_id) REFERENCES productos(id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE pagos (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  pedido_id INT NOT NULL,
+  provider VARCHAR(32) NOT NULL DEFAULT 'mercadopago',
+  provider_payment_id VARCHAR(64) UNIQUE,
+  status ENUM('approved','in_process','rejected','refunded','charged_back') NOT NULL DEFAULT 'in_process',
+  monto DECIMAL(12,2) NOT NULL,
+  moneda CHAR(3) NOT NULL DEFAULT 'COP',
+  raw_payload JSON,
+  reconciled_at DATETIME NULL,
+  created_at DATETIME NOT NULL,
+  FOREIGN KEY (pedido_id) REFERENCES pedidos(id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE cupones (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  codigo VARCHAR(64) UNIQUE NOT NULL,
+  tipo ENUM('percent','fixed') NOT NULL,
+  valor DECIMAL(12,2) NOT NULL,
+  minimo_compra DECIMAL(12,2) DEFAULT 0,
+  max_uso_total INT NULL,
+  vence_at DATETIME NULL,
+  activo TINYINT(1) DEFAULT 1
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/electronica.php
+++ b/electronica.php
@@ -295,23 +295,25 @@ nav a:hover {
     color: #667eea;
 }
 
-.checkout-btn {
-    background: linear-gradient(45deg, #28a745, #20c997);
-    color: white;
-    padding: 1rem 2rem;
-    border: none;
-    border-radius: 25px;
-    font-weight: 600;
-    cursor: pointer;
-    width: 100%;
-    font-size: 1.1rem;
-    transition: all 0.3s ease;
-}
+        .payment-methods {
+            margin-top: 1rem;
+            text-align: center;
+            display: none;
+        }
 
-.checkout-btn:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 5px 15px rgba(40, 167, 69, 0.4);
-}
+        .payment-methods h4 {
+            margin-bottom: 0.5rem;
+        }
+
+        .pay-btn {
+            display: block;
+            background: linear-gradient(45deg, #667eea, #764ba2);
+            color: white;
+            padding: 0.7rem;
+            border-radius: 20px;
+            text-decoration: none;
+            margin: 0.3rem 0;
+        }
 
 .whatsapp-float {
     position: fixed;
@@ -609,10 +611,16 @@ footer strong {
         <div class="cart-total">
             Total: $<span id="cart-total">0</span>
         </div>
-        <button class="checkout-btn" onclick="checkout()">Proceder al Pago</button>
+        <div class="payment-methods" id="payment-methods">
+            <h4>Métodos de Pago</h4>
+            <a href="https://checkout.wompi.co" target="_blank" class="pay-btn">Wompi</a>
+            <a href="https://www.mercadopago.com" target="_blank" class="pay-btn">MercadoPago</a>
+            <a href="https://www.pse.com.co" target="_blank" class="pay-btn">PSE</a>
+        </div>
     </div>
 </div>
 
+<script src="carrito.js"></script>
 <script>
 // ===============================
 // DATOS DE PRODUCTOS ELECTRONICA
@@ -945,7 +953,10 @@ window.addEventListener('DOMContentLoaded', cargarProductosElectronica);
 // FUNCIONES EXTRA (EJEMPLO)
 // ===============================
 function agregarAlCarrito(idProducto) {
-    alert(`Producto ${idProducto} agregado al carrito (aquí puedes poner la lógica real)`);
+    const producto = productosElectronica.find(p => p.id === idProducto);
+    if (producto) {
+        agregarProductoCarrito(producto);
+    }
 }
 </script>
 

--- a/emails/order_confirm.php
+++ b/emails/order_confirm.php
@@ -1,0 +1,22 @@
+<?php
+/** @var array $order */
+/** @var array $items */
+?>
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Confirmación de pedido</title>
+</head>
+<body>
+<h1>Gracias por tu compra</h1>
+<p>Pedido #<?= htmlspecialchars($order['id']); ?> confirmado.</p>
+<table>
+<tr><th>Producto</th><th>Cant</th><th>Total</th></tr>
+<?php foreach ($items as $it): ?>
+<tr><td><?= htmlspecialchars($it['nombre_snapshot']); ?></td><td><?= $it['cantidad']; ?></td><td>$<?= number_format($it['total'],2); ?></td></tr>
+<?php endforeach; ?>
+</table>
+<p>Total pagado: $<?= number_format($order['total'],2); ?></p>
+</body>
+</html>

--- a/gaming.php
+++ b/gaming.php
@@ -152,7 +152,9 @@
     .close-cart{background:none;border:none;font-size:1.6rem;cursor:pointer;color:#222}
     .cart-item{display:flex;justify-content:space-between;align-items:center;padding:8px 0;border-bottom:1px solid #eee}
     .cart-total{font-size:1.15rem;font-weight:700;text-align:right;margin-top:12px;color:#222}
-    .checkout-btn{background:linear-gradient(45deg,#28a745,#20c997);color:#fff;padding:12px;border:none;border-radius:12px;font-weight:800;cursor:pointer;width:100%;margin-top:12px}
+    .payment-methods{margin-top:1rem;text-align:center;display:none}
+    .payment-methods h4{margin-bottom:.5rem}
+    .pay-btn{display:block;background:linear-gradient(45deg,#667eea,#764ba2);color:#fff;padding:.7rem;border-radius:20px;text-decoration:none;margin:.3rem 0}
 
     footer{background:#333;color:white;padding:3rem 2rem 1rem;text-align:center}
     .footer-content{max-width:1200px;margin:0 auto}
@@ -172,14 +174,14 @@
       </div>
       <nav>
         <ul>
-          <li><a href="componentes.php">Componentes</a></li>
-          <li><a href="audio.php">Audio</a></li>
-          <li><a href="cableado.php">Cableado</a></li>
-          <li><a href="gaming.php" class="active">Gaming</a></li>
-          <li><a href="electronica.php">Electrónica</a></li>
-          <li><a href="varios.php">Varios</a></li>
-        </ul>
-      </nav>
+        <li><a href="componentes.php">Componentes</a></li>
+        <li><a href="audio.php">Audio</a></li>
+        <li><a href="cableado.php">Cableado</a></li>
+        <li><a href="gaming.php" class="active">Gaming</a></li>
+        <li><a href="electronica.php">Electrónica</a></li>
+        <li><a href="varios.php">Varios</a></li>
+      </ul>
+    </nav>
       <a href="#" class="cart-btn" onclick="toggleCart()">🛒 Carrito <span class="cart-count" id="cart-count">0</span></a>
     </div>
 
@@ -259,7 +261,12 @@
       </div>
       <div id="cart-items"></div>
       <div class="cart-total">Total: $<span id="cart-total">0</span></div>
-      <button class="checkout-btn" onclick="checkout()">🟢 Proceder al Pago</button>
+      <div class="payment-methods" id="payment-methods">
+        <h4>Métodos de Pago</h4>
+        <a href="https://checkout.wompi.co" target="_blank" class="pay-btn">Wompi</a>
+        <a href="https://www.mercadopago.com" target="_blank" class="pay-btn">MercadoPago</a>
+        <a href="https://www.pse.com.co" target="_blank" class="pay-btn">PSE</a>
+      </div>
     </div>
   </div>
 
@@ -275,8 +282,9 @@
       <p>Visítanos en: <strong>digitalrp.store</strong></p>
       <p>📱 WhatsApp: +57 300 123 4567 | ✉️ info@digitalrp.store</p>
     </div>
-  </footer>
+</footer>
 
+  <script src="carrito.js"></script>
   <script>
     /***** Datos de productos (igual a lo que tenías) *****/
     const productosGaming = [
@@ -292,60 +300,15 @@
       { id:10, nombre:"Volante Gamer Force Feedback", precio:1800000, imagenes:["https://images.unsplash.com/photo-1576153192396-180ecef15b0c?q=80&w=1974"], descripcion:"Volante con force feedback 900° y pedales metálicos", marca:"LOGITECH" }
     ];
 
-    // carrito
-    let carrito = JSON.parse(localStorage.getItem('carrito')) || [];
+    // animación de contador
+    function animarCarrito(){ const cc = document.getElementById('cart-count'); cc.classList.add('animate'); setTimeout(()=>cc.classList.remove('animate'),500); }
 
-    // notificación breve
-    function mostrarNotificacion(mensaje){
-      const n = document.createElement('div');
-      n.style.cssText = 'position:fixed;top:100px;right:20px;background:linear-gradient(45deg,#00eeff,#ff00aa);color:#fff;padding:12px 18px;border-radius:8px;box-shadow:0 8px 30px rgba(0,0,0,.24);z-index:4000;font-weight:700';
-      n.textContent = mensaje;
-      document.body.appendChild(n);
-      setTimeout(()=> n.remove(),2400);
-    }
-
-    // agregar al carrito
     function agregarAlCarrito(id){
       const producto = productosGaming.find(p=>p.id===id);
       if(producto){
-        carrito.push(producto);
-        localStorage.setItem('carrito', JSON.stringify(carrito));
-        actualizarCarrito();
+        agregarProductoCarrito(producto);
         animarCarrito();
-        mostrarNotificacion('Producto agregado al carrito');
       }
-    }
-    function animarCarrito(){ const cc = document.getElementById('cart-count'); cc.classList.add('animate'); setTimeout(()=>cc.classList.remove('animate'),500); }
-
-    function actualizarCarrito(){
-      const cartCount = document.getElementById('cart-count');
-      const cartItems = document.getElementById('cart-items');
-      const cartTotal = document.getElementById('cart-total');
-      cartCount.textContent = carrito.length;
-      cartItems.innerHTML = '';
-      let total = 0;
-      carrito.forEach((item, index) => {
-        total += item.precio;
-        const div = document.createElement('div');
-        div.className = 'cart-item';
-        div.innerHTML = `<span>${item.nombre}</span><span>$${item.precio.toLocaleString()}</span>\n          <button onclick="eliminarDelCarrito(${index})" style="background:#ff4757;color:#fff;border:none;padding:.3rem .6rem;border-radius:5px;cursor:pointer">×</button>`;
-        cartItems.appendChild(div);
-      });
-      cartTotal.textContent = total.toLocaleString();
-    }
-    function eliminarDelCarrito(i){ carrito.splice(i,1); localStorage.setItem('carrito',JSON.stringify(carrito)); actualizarCarrito(); }
-
-    function toggleCart(){
-      const m = document.getElementById('cart-modal');
-      m.style.display = m.style.display === 'block' ? 'none' : 'block';
-    }
-
-    function checkout(){
-      if(carrito.length===0){ alert('Tu carrito está vacío'); return; }
-      let msg="Hola! Quiero hacer el siguiente pedido de productos gaming:%0A%0A"; let total=0;
-      carrito.forEach(i=>{ msg += `• ${i.nombre} - $${i.precio.toLocaleString()}%0A`; total+=i.precio; });
-      msg += `%0ATotal: $${total.toLocaleString()}%0A%0AMi información:%0ANombre:%0ADirección:%0ATel:`;
-      window.open(`https://wa.me/573001234567?text=${msg}`,'_blank');
     }
 
     /* ====== GRID RENDER ====== */

--- a/index.php
+++ b/index.php
@@ -605,22 +605,24 @@
             color: #667eea;
         }
 
-        .checkout-btn {
-            background: linear-gradient(45deg, #28a745, #20c997);
-            color: white;
-            padding: 1rem 2rem;
-            border: none;
-            border-radius: 25px;
-            font-weight: 600;
-            cursor: pointer;
-            width: 100%;
-            font-size: 1.1rem;
-            transition: all 0.3s ease;
+        .payment-methods {
+            margin-top: 1rem;
+            text-align: center;
+            display: none;
         }
 
-        .checkout-btn:hover {
-            transform: translateY(-2px);
-            box-shadow: 0 5px 15px rgba(40, 167, 69, 0.4);
+        .payment-methods h4 {
+            margin-bottom: 0.5rem;
+        }
+
+        .pay-btn {
+            display: block;
+            background: linear-gradient(45deg, #667eea, #764ba2);
+            color: white;
+            padding: 0.7rem;
+            border-radius: 20px;
+            text-decoration: none;
+            margin: 0.3rem 0;
         }
 
         /* Footer */
@@ -881,7 +883,12 @@
             <div class="cart-total">
                 Total: $<span id="cart-total">0</span>
             </div>
-            <button class="checkout-btn" onclick="checkout()">Proceder al Pago</button>
+            <div class="payment-methods" id="payment-methods">
+                <h4>Métodos de Pago</h4>
+                <a href="https://checkout.wompi.co" target="_blank" class="pay-btn">Wompi</a>
+                <a href="https://www.mercadopago.com" target="_blank" class="pay-btn">MercadoPago</a>
+                <a href="https://www.pse.com.co" target="_blank" class="pay-btn">PSE</a>
+            </div>
         </div>
     </div>
 
@@ -899,6 +906,7 @@
         </div>
     </footer>
 
+    <script src="carrito.js"></script>
     <script>
         // Datos de productos con sistema de imágenes
         const productos = {
@@ -937,120 +945,18 @@
         };
 
         // Carrito de compras
-        let carrito = JSON.parse(localStorage.getItem('carrito')) || [];
-
-        // Función para agregar al carrito (reutilizada por el carrusel)
         function agregarAlCarrito(id) {
             let producto = null;
             for (let categoria in productos) {
-                producto = productos[categoria].find(p => p.id === id);
-                if (producto) break;
-            }
-
-            if (producto) {
-                carrito.push(producto);
-                localStorage.setItem('carrito', JSON.stringify(carrito));
-                actualizarCarrito();
-                mostrarNotificacion('Producto agregado al carrito');
-            }
-        }
-
-        // Función para actualizar el carrito
-        function actualizarCarrito() {
-            const cartCount = document.getElementById('cart-count');
-            const cartItems = document.getElementById('cart-items');
-            const cartTotal = document.getElementById('cart-total');
-
-            cartCount.textContent = carrito.length;
-
-            cartItems.innerHTML = '';
-            let total = 0;
-
-            carrito.forEach((item, index) => {
-                const cartItem = document.createElement('div');
-                cartItem.className = 'cart-item';
-                cartItem.innerHTML = `
-                    <span>${item.nombre}</span>
-                    <span>$${item.precio.toLocaleString()}</span>
-                    <button onclick="eliminarDelCarrito(${index})" style="background: #ff4757; color: white; border: none; padding: 0.2rem 0.5rem; border-radius: 5px; cursor: pointer;">×</button>
-                `;
-                cartItems.appendChild(cartItem);
-                total += item.precio;
-            });
-
-            cartTotal.textContent = total.toLocaleString();
-        }
-
-        // Función para eliminar del carrito
-        function eliminarDelCarrito(index) {
-            carrito.splice(index, 1);
-            localStorage.setItem('carrito', JSON.stringify(carrito));
-            actualizarCarrito();
-        }
-
-        // Función para alternar el carrito
-        function toggleCart() {
-            const cartModal = document.getElementById('cart-modal');
-            cartModal.style.display = cartModal.style.display === 'block' ? 'none' : 'block';
-        }
-
-        // Función para proceder al pago
-        function checkout() {
-            if (carrito.length === 0) {
-                alert('Tu carrito está vacío');
-                return;
-            }
-
-            // Crear mensaje para WhatsApp
-            let mensaje = "Hola! Quiero hacer el siguiente pedido:%0A%0A";
-            let total = 0;
-
-            carrito.forEach(item => {
-                mensaje += `• ${item.nombre} - $${item.precio.toLocaleString()}%0A`;
-                total += item.precio;
-            });
-
-            mensaje += `%0ATotal: $${total.toLocaleString()}%0A%0A¿Podrían confirmar disponibilidad y método de pago?`;
-
-            // Abrir WhatsApp con el mensaje
-            window.open(`https://wa.me/573001234567?text=${mensaje}`, '_blank');
-        }
-
-        // Función para mostrar notificaciones
-        function mostrarNotificacion(mensaje) {
-            const notificacion = document.createElement('div');
-            notificacion.style.cssText = `
-                position: fixed;
-                top: 100px;
-                right: 20px;
-                background: #28a745;
-                color: white;
-                padding: 15px 25px;
-                border-radius: 8px;
-                box-shadow: 0 5px 15px rgba(0, 0, 0, 0.2);
-                z-index: 3000;
-                animation: fadeInOut 3s ease;
-            `;
-            notificacion.textContent = mensaje;
-            document.body.appendChild(notificacion);
-
-            // Crear animación
-            const style = document.createElement('style');
-            style.textContent = `
-                @keyframes fadeInOut {
-                    0% { opacity: 0; transform: translateY(-20px); }
-                    10% { opacity: 1; transform: translateY(0); }
-                    90% { opacity: 1; transform: translateY(0); }
-                    100% { opacity: 0; transform: translateY(-20px); }
+                const encontrado = productos[categoria].find(p => p.id === id);
+                if (encontrado) {
+                    producto = encontrado;
+                    break;
                 }
-            `;
-            document.head.appendChild(style);
-
-            // Eliminar después de 3 segundos
-            setTimeout(() => {
-                if (notificacion.parentElement) document.body.removeChild(notificacion);
-                if (style.parentElement) document.head.removeChild(style);
-            }, 3000);
+            }
+            if (producto) {
+                agregarProductoCarrito(producto);
+            }
         }
 
         /* ============================

--- a/public/assets/css/main.css
+++ b/public/assets/css/main.css
@@ -1,0 +1,8 @@
+body{font-family:Arial,Helvetica,sans-serif;margin:0;padding:0;background:#f5f5f5;color:#333}
+header,footer{background:#222;color:#fff;padding:1rem}
+.container{width:90%;max-width:960px;margin:0 auto}
+img{max-width:100%;height:auto;display:block}
+.btn{display:inline-block;padding:.5rem 1rem;background:#007bff;color:#fff;text-decoration:none;border-radius:4px}
+.btn:hover{background:#0056b3}
+.cart-table{width:100%;border-collapse:collapse}
+.cart-table th,.cart-table td{padding:.5rem;border-bottom:1px solid #ddd;text-align:left}

--- a/public/assets/js/main.js
+++ b/public/assets/js/main.js
@@ -1,0 +1,12 @@
+document.addEventListener('submit',function(e){
+  if(e.target.matches('.add-to-cart')){
+    e.preventDefault();
+    fetch('/cart/add.php',{method:'POST',body:new FormData(e.target)})
+      .then(r=>r.json()).then(()=>location.reload());
+  }
+  if(e.target.matches('.cart-update')){
+    e.preventDefault();
+    fetch('/cart/update.php',{method:'POST',body:new FormData(e.target)})
+      .then(r=>r.json()).then(()=>location.reload());
+  }
+});

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: /scripts/sitemap_generate.php

--- a/scripts/sitemap_generate.php
+++ b/scripts/sitemap_generate.php
@@ -1,0 +1,28 @@
+<?php
+require_once __DIR__ . '/../vendor/autoload.php';
+spl_autoload_register(function($class){$prefix='App\\';if(strncmp($class,$prefix,strlen($prefix))===0){$file=__DIR__.'/../src/'.str_replace('\\','/',substr($class,strlen($prefix))).'.php';if(file_exists($file))require $file;}});
+
+$pdo = require __DIR__ . '/../config/db.php';
+$config = require __DIR__ . '/../config/config.php';
+header('Content-Type: application/xml');
+$base = rtrim($config['app_url'], '/');
+$urls = [
+    $base . '/index.php',
+    $base . '/audio.php',
+    $base . '/cableado.php',
+    $base . '/componentes.php',
+    $base . '/electronica.php',
+    $base . '/gaming.php',
+    $base . '/varios.php',
+];
+$stmt = $pdo->query('SELECT id FROM productos');
+while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+    $urls[] = $base . '/producto.php?id=' . $row['id'];
+}
+
+echo "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n";
+echo "<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">\n";
+foreach ($urls as $u) {
+    echo "  <url><loc>{$u}</loc></url>\n";
+}
+echo "</urlset>";

--- a/src/Cart/Cart.php
+++ b/src/Cart/Cart.php
@@ -1,0 +1,110 @@
+<?php
+namespace App\Cart;
+
+class Cart
+{
+    private static function init(): void
+    {
+        if (session_status() !== PHP_SESSION_ACTIVE) {
+            session_start();
+        }
+        if (!isset($_SESSION['cart'])) {
+            $_SESSION['cart'] = ['items' => [], 'coupon' => null, 'totals' => self::calculateTotals([])];
+        }
+    }
+
+    private static function calculateTotals(array $items, ?array $coupon = null): array
+    {
+        $subtotal = 0;
+        foreach ($items as $it) {
+            $subtotal += $it['precio'] * $it['qty'];
+        }
+        $descuento = 0;
+        if ($coupon) {
+            if ($coupon['tipo'] === 'percent') {
+                $descuento = $subtotal * ($coupon['valor'] / 100);
+            } elseif ($coupon['tipo'] === 'fixed') {
+                $descuento = $coupon['valor'];
+            }
+        }
+        $total = max($subtotal - $descuento, 0);
+        return [
+            'subtotal' => $subtotal,
+            'descuento' => $descuento,
+            'envio' => 0,
+            'impuestos' => 0,
+            'total' => $total,
+        ];
+    }
+
+    public static function get(): array
+    {
+        self::init();
+        return $_SESSION['cart'];
+    }
+
+    private static function persist(): void
+    {
+        $_SESSION['cart']['totals'] = self::calculateTotals($_SESSION['cart']['items'], $_SESSION['cart']['coupon']);
+    }
+
+    public static function add(int $id, string $nombre, float $precio, int $qty, string $imagen, int $stock): void
+    {
+        self::init();
+        if ($qty < 1 || $qty > $stock) {
+            throw new \InvalidArgumentException('Cantidad inválida');
+        }
+        if (isset($_SESSION['cart']['items'][$id])) {
+            $newQty = $_SESSION['cart']['items'][$id]['qty'] + $qty;
+            if ($newQty > $stock) {
+                throw new \RuntimeException('Sin stock suficiente');
+            }
+            $_SESSION['cart']['items'][$id]['qty'] = $newQty;
+        } else {
+            $_SESSION['cart']['items'][$id] = [
+                'id' => $id,
+                'nombre' => $nombre,
+                'precio' => $precio,
+                'qty' => $qty,
+                'imagen_url' => $imagen,
+            ];
+        }
+        self::persist();
+    }
+
+    public static function update(int $id, int $qty, int $stock): void
+    {
+        self::init();
+        if (!isset($_SESSION['cart']['items'][$id])) {
+            return;
+        }
+        if ($qty < 1) {
+            unset($_SESSION['cart']['items'][$id]);
+        } elseif ($qty <= $stock) {
+            $_SESSION['cart']['items'][$id]['qty'] = $qty;
+        } else {
+            throw new \RuntimeException('Sin stock suficiente');
+        }
+        self::persist();
+    }
+
+    public static function remove(int $id): void
+    {
+        self::init();
+        unset($_SESSION['cart']['items'][$id]);
+        self::persist();
+    }
+
+    public static function clear(): void
+    {
+        self::init();
+        $_SESSION['cart'] = ['items' => [], 'coupon' => null, 'totals' => self::calculateTotals([])];
+    }
+
+    public static function applyCoupon(?array $coupon): void
+    {
+        self::init();
+        $_SESSION['cart']['coupon'] = $coupon;
+        self::persist();
+    }
+}

--- a/src/Orders/OrderService.php
+++ b/src/Orders/OrderService.php
@@ -1,0 +1,107 @@
+<?php
+namespace App\Orders;
+
+use PDO;
+use PHPMailer\PHPMailer\PHPMailer;
+use PHPMailer\PHPMailer\Exception as MailException;
+
+class OrderService
+{
+    private PDO $db;
+    private array $config;
+
+    public function __construct(PDO $db, array $config)
+    {
+        $this->db = $db;
+        $this->config = $config;
+    }
+
+    public function createPending(string $email, string $nombre, array $cart): int
+    {
+        $this->db->beginTransaction();
+        $totals = $cart['totals'];
+        $stmt = $this->db->prepare("INSERT INTO pedidos (email, nombre, subtotal, descuentos, envio, impuestos, total, moneda, estado, created_at, updated_at) VALUES (?,?,?,?,?,?,?,?, 'pending', NOW(), NOW())");
+        $stmt->execute([
+            $email,
+            $nombre,
+            $totals['subtotal'],
+            $totals['descuento'],
+            $totals['envio'],
+            $totals['impuestos'],
+            $totals['total'],
+            'COP'
+        ]);
+        $pedidoId = (int)$this->db->lastInsertId();
+        $stmtDet = $this->db->prepare("INSERT INTO detalle_pedido (pedido_id, producto_id, nombre_snapshot, precio_unitario, cantidad, subtotal, impuestos, total) VALUES (?,?,?,?,?,?,?,?)");
+        foreach ($cart['items'] as $item) {
+            $subtotal = $item['precio'] * $item['qty'];
+            $stmtDet->execute([
+                $pedidoId,
+                $item['id'],
+                $item['nombre'],
+                $item['precio'],
+                $item['qty'],
+                $subtotal,
+                0,
+                $subtotal
+            ]);
+        }
+        $stmtPago = $this->db->prepare("INSERT INTO pagos (pedido_id, provider, status, monto, raw_payload, created_at) VALUES (?, 'mercadopago', 'in_process', ?, NULL, NOW())");
+        $stmtPago->execute([$pedidoId, $totals['total']]);
+        $this->db->commit();
+        return $pedidoId;
+    }
+
+    public function updatePayment(int $pedidoId, string $status, string $providerPaymentId, float $monto, array $raw): void
+    {
+        $stmt = $this->db->prepare("UPDATE pagos SET provider_payment_id=?, status=?, raw_payload=?, reconciled_at=NOW() WHERE pedido_id=?");
+        $stmt->execute([$providerPaymentId, $status, json_encode($raw), $pedidoId]);
+
+        if ($status === 'approved') {
+            $this->db->beginTransaction();
+            $this->db->prepare("UPDATE pedidos SET estado='paid', updated_at=NOW() WHERE id=?")->execute([$pedidoId]);
+            $itemsStmt = $this->db->prepare("SELECT producto_id, cantidad, nombre_snapshot, total FROM detalle_pedido WHERE pedido_id=?");
+            $itemsStmt->execute([$pedidoId]);
+            $items = $itemsStmt->fetchAll(PDO::FETCH_ASSOC);
+            foreach ($items as $row) {
+                $this->db->prepare("UPDATE productos SET stock = stock - ? WHERE id=?")->execute([$row['cantidad'], $row['producto_id']]);
+            }
+            $this->db->commit();
+            // send email
+            $order = $this->db->prepare("SELECT * FROM pedidos WHERE id=?");
+            $order->execute([$pedidoId]);
+            $orderData = $order->fetch(PDO::FETCH_ASSOC);
+            $this->sendEmail($orderData, $items);
+        } elseif (in_array($status, ['rejected','refunded','charged_back'], true)) {
+            $this->db->prepare("UPDATE pedidos SET estado=? , updated_at=NOW() WHERE id=?")->execute([$status === 'rejected' ? 'canceled' : $status, $pedidoId]);
+        }
+    }
+
+    private function sendEmail(array $order, array $items): void
+    {
+        try {
+            $mail = new PHPMailer(true);
+            $smtp = $this->config['smtp'];
+            $mail->isSMTP();
+            $mail->Host = $smtp['host'];
+            $mail->SMTPAuth = true;
+            $mail->Username = $smtp['user'];
+            $mail->Password = $smtp['pass'];
+            $mail->SMTPSecure = $smtp['secure'];
+            $mail->Port = $smtp['port'];
+            $mail->setFrom($smtp['user'], 'Tienda');
+            $mail->addAddress($order['email'], $order['nombre']);
+            $mail->isHTML(true);
+            $mail->Subject = 'Confirmación de pedido';
+            ob_start();
+            $orderVar = $order; // local variable names to pass
+            $itemsVar = $items;
+            $order = $orderVar; $items = $itemsVar;
+            include __DIR__ . '/../../emails/order_confirm.php';
+            $mail->Body = ob_get_clean();
+            $mail->send();
+        } catch (MailException $e) {
+            // log error in production
+        }
+    }
+}

--- a/src/Payments/MercadoPagoClient.php
+++ b/src/Payments/MercadoPagoClient.php
@@ -1,0 +1,44 @@
+<?php
+namespace App\Payments;
+
+use MercadoPago\SDK;
+use MercadoPago\Preference;
+use MercadoPago\Item;
+use MercadoPago\Payment;
+
+class MercadoPagoClient
+{
+    public function __construct(string $accessToken)
+    {
+        SDK::setAccessToken($accessToken);
+    }
+
+    public function createPreference(array $cartItems, string $payerEmail, string $backSuccess, string $backPending, string $backFailure, string $notificationUrl): Preference
+    {
+        $preference = new Preference();
+        $items = [];
+        foreach ($cartItems as $item) {
+            $i = new Item();
+            $i->title = $item['nombre'];
+            $i->quantity = $item['qty'];
+            $i->unit_price = $item['precio'];
+            $items[] = $i;
+        }
+        $preference->items = $items;
+        $preference->payer = ['email' => $payerEmail];
+        $preference->back_urls = [
+            'success' => $backSuccess,
+            'pending' => $backPending,
+            'failure' => $backFailure,
+        ];
+        $preference->auto_return = 'approved';
+        $preference->notification_url = $notificationUrl;
+        $preference->save();
+        return $preference;
+    }
+
+    public function getPayment(int $id): Payment
+    {
+        return Payment::find_by_id($id);
+    }
+}

--- a/src/Security/Csrf.php
+++ b/src/Security/Csrf.php
@@ -1,0 +1,24 @@
+<?php
+namespace App\Security;
+
+class Csrf
+{
+    public static function token(): string
+    {
+        if (session_status() !== PHP_SESSION_ACTIVE) {
+            session_start();
+        }
+        if (empty($_SESSION['_csrf'])) {
+            $_SESSION['_csrf'] = bin2hex(random_bytes(32));
+        }
+        return $_SESSION['_csrf'];
+    }
+
+    public static function validate(?string $token): bool
+    {
+        if (session_status() !== PHP_SESSION_ACTIVE) {
+            session_start();
+        }
+        return $token && isset($_SESSION['_csrf']) && hash_equals($_SESSION['_csrf'], $token);
+    }
+}

--- a/src/Security/SecurityHeaders.php
+++ b/src/Security/SecurityHeaders.php
@@ -1,0 +1,13 @@
+<?php
+namespace App\Security;
+
+class SecurityHeaders
+{
+    public static function apply(): void
+    {
+        header("Content-Security-Policy: default-src 'self'; img-src 'self' data:; script-src 'self'; style-src 'self';");
+        header('X-Frame-Options: DENY');
+        header('X-Content-Type-Options: nosniff');
+        header('Referrer-Policy: strict-origin-when-cross-origin');
+    }
+}

--- a/templates/layout.php
+++ b/templates/layout.php
@@ -1,0 +1,26 @@
+<?php
+use App\Security\SecurityHeaders;
+SecurityHeaders::apply();
+if (session_status() !== PHP_SESSION_ACTIVE) {
+    session_start();
+}
+?>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title><?= htmlspecialchars($title ?? 'Tienda'); ?></title>
+<meta property="og:title" content="<?= htmlspecialchars($ogTitle ?? ($title ?? 'Tienda')); ?>">
+<meta property="og:type" content="website">
+<meta property="og:url" content="<?= htmlspecialchars($ogUrl ?? ''); ?>">
+<meta property="og:image" content="<?= htmlspecialchars($ogImage ?? '/public/assets/img/logo.png'); ?>">
+<meta name="twitter:card" content="summary_large_image">
+<link rel="preconnect" href="https://secure.mlstatic.com">
+<link rel="stylesheet" href="/public/assets/css/main.css">
+</head>
+<body>
+<?= $content ?? '' ?>
+<script src="/public/assets/js/main.js"></script>
+</body>
+</html>

--- a/varios.php
+++ b/varios.php
@@ -295,23 +295,25 @@ nav a:hover {
     color: #667eea;
 }
 
-.checkout-btn {
-    background: linear-gradient(45deg, #28a745, #20c997);
-    color: white;
-    padding: 1rem 2rem;
-    border: none;
-    border-radius: 25px;
-    font-weight: 600;
-    cursor: pointer;
-    width: 100%;
-    font-size: 1.1rem;
-    transition: all 0.3s ease;
-}
+        .payment-methods {
+            margin-top: 1rem;
+            text-align: center;
+            display: none;
+        }
 
-.checkout-btn:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 5px 15px rgba(40, 167, 69, 0.4);
-}
+        .payment-methods h4 {
+            margin-bottom: 0.5rem;
+        }
+
+        .pay-btn {
+            display: block;
+            background: linear-gradient(45deg, #667eea, #764ba2);
+            color: white;
+            padding: 0.7rem;
+            border-radius: 20px;
+            text-decoration: none;
+            margin: 0.3rem 0;
+        }
 
 .whatsapp-float {
     position: fixed;
@@ -609,10 +611,16 @@ footer strong {
         <div class="cart-total">
             Total: $<span id="cart-total">0</span>
         </div>
-        <button class="checkout-btn" onclick="checkout()">Proceder al Pago</button>
+        <div class="payment-methods" id="payment-methods">
+            <h4>Métodos de Pago</h4>
+            <a href="https://checkout.wompi.co" target="_blank" class="pay-btn">Wompi</a>
+            <a href="https://www.mercadopago.com" target="_blank" class="pay-btn">MercadoPago</a>
+            <a href="https://www.pse.com.co" target="_blank" class="pay-btn">PSE</a>
+        </div>
     </div>
 </div>
 
+<script src="carrito.js"></script>
 <script>
 // ===============================
 // DATOS DE PRODUCTOS VARIOS
@@ -945,7 +953,10 @@ window.addEventListener('DOMContentLoaded', cargarProductosVarios);
 // FUNCIONES EXTRA (EJEMPLO)
 // ===============================
 function agregarAlCarrito(idProducto) {
-    alert(`Producto ${idProducto} agregado al carrito (aquí puedes poner la lógica real)`);
+    const producto = productosVarios.find(p => p.id === idProducto);
+    if (producto) {
+        agregarProductoCarrito(producto);
+    }
 }
 </script>
 

--- a/webhooks/mercadopago.php
+++ b/webhooks/mercadopago.php
@@ -1,0 +1,23 @@
+<?php
+require_once __DIR__ . '/../vendor/autoload.php';
+spl_autoload_register(function($class){$prefix='App\\';if(strncmp($class,$prefix,strlen($prefix))===0){$file=__DIR__.'/../src/'.str_replace('\\','/',substr($class,strlen($prefix))).'.php';if(file_exists($file))require $file;}});
+
+use App\Payments\MercadoPagoClient;
+use App\Orders\OrderService;
+
+$input = file_get_contents('php://input');
+$data = json_decode($input, true);
+$paymentId = $data['data']['id'] ?? $data['id'] ?? null;
+$orderId = $_GET['order_id'] ?? null;
+if (!$paymentId || !$orderId) {
+    http_response_code(400);
+    exit('bad request');
+}
+$config = require __DIR__ . '/../config/config.php';
+$pdo = require __DIR__ . '/../config/db.php';
+$mp = new MercadoPagoClient($config['mercadopago']['access_token']);
+$payment = $mp->getPayment((int)$paymentId);
+    $orderService = new OrderService($pdo, $config);
+$orderService->updatePayment((int)$orderId, $payment->status, (string)$payment->id, (float)$payment->transaction_amount, (array)$payment);
+http_response_code(200);
+echo 'ok';


### PR DESCRIPTION
## Summary
- remove standalone payment methods page and navigation link
- centralize cart logic in new `carrito.js`
- show Wompi, MercadoPago and PSE buttons inside cart once products are added

## Testing
- `php -l index.php componentes.php audio.php cableado.php gaming.php electronica.php varios.php buscar.php`


------
https://chatgpt.com/codex/tasks/task_b_6899e0e4b5788321a5ff43fd4c5b109a